### PR TITLE
accommodate delayed join inputs

### DIFF
--- a/diaspore/src/main/java/com/bytefacets/diaspore/join/JoinChangeTracker.java
+++ b/diaspore/src/main/java/com/bytefacets/diaspore/join/JoinChangeTracker.java
@@ -79,7 +79,7 @@ final class JoinChangeTracker implements JoinListener {
         if (!changedRows.isEmpty()) {
             manager.notifyChanges(changedRows, outboundFieldSet);
         }
-        if (removedRowConsumer != null) {
+        if (removedRowConsumer != null && !removedRows.isEmpty()) {
             removedRows.forEach(removedRowConsumer);
         }
         reset();

--- a/diaspore/src/main/java/com/bytefacets/diaspore/join/JoinMapper.java
+++ b/diaspore/src/main/java/com/bytefacets/diaspore/join/JoinMapper.java
@@ -16,6 +16,8 @@ interface JoinMapper {
 
     RowMapper rightMapper();
 
+    void clear();
+
     void leftRowAdd(int leftRow);
 
     void rightRowAdd(int rightRow);

--- a/diaspore/src/main/java/com/bytefacets/diaspore/join/LookupJoinMapper.java
+++ b/diaspore/src/main/java/com/bytefacets/diaspore/join/LookupJoinMapper.java
@@ -10,6 +10,7 @@ import com.bytefacets.collections.types.Pack;
 import com.bytefacets.diaspore.RowProvider;
 import com.bytefacets.diaspore.common.BitSetRowProvider;
 import com.bytefacets.diaspore.schema.RowMapper;
+import java.util.Arrays;
 import java.util.BitSet;
 
 final class LookupJoinMapper implements JoinMapper {
@@ -67,6 +68,14 @@ final class LookupJoinMapper implements JoinMapper {
             }
             return -1;
         };
+    }
+
+    @Override
+    public void clear() {
+        Arrays.fill(leftRowToKey, UNSET);
+        Arrays.fill(rightRowToKey, UNSET);
+        Arrays.fill(keyToLeftRight, EMPTY_MAPPING);
+        activeRows.clear();
     }
 
     @Override

--- a/diaspore/src/testFixtures/java/com/bytefacets/diaspore/validation/ValidationOperator.java
+++ b/diaspore/src/testFixtures/java/com/bytefacets/diaspore/validation/ValidationOperator.java
@@ -87,6 +87,7 @@ public final class ValidationOperator {
                 currentChangeSet.schema(toMap(schema.fields()));
             } else {
                 currentChangeSet.nullSchema();
+                calculatedActiveRows.clear();
             }
         }
 


### PR DESCRIPTION
when one of the inputs into the join is delayed, row changes on the connected input caused NPE.

the fix here is to block row changes until all inputs are connected and when the last input is connected to catch up the other side.

Fixes #1