### PR TITLE
fix for suppressing change forwarding in GroupBy when unreferenced row

### DIFF
--- a/spinel/src/main/java/com/bytefacets/spinel/groupby/GroupBy.java
+++ b/spinel/src/main/java/com/bytefacets/spinel/groupby/GroupBy.java
@@ -204,12 +204,14 @@ public final class GroupBy implements InputProvider, OutputProvider {
         private void processChangesForStableGroups(
                 final IntIterable rows,
                 final GenericIndexedSet<AggregationFunction> changedFunctions) {
-            rows.forEach(
-                    row -> {
-                        final int oldGroup = groupMapping.groupOfInboundRow(row);
-                        processGroupUpdateFromChange(oldGroup, row);
-                    });
-            updateChangedFunctions(changedFunctions);
+            if (!changedFunctions.isEmpty()) {
+                rows.forEach(
+                        row -> {
+                            final int oldGroup = groupMapping.groupOfInboundRow(row);
+                            processGroupUpdateFromChange(oldGroup, row);
+                        });
+                updateChangedFunctions(changedFunctions);
+            }
         }
 
         @Override

--- a/spinel/src/test/java/com/bytefacets/spinel/groupby/GroupByTest.java
+++ b/spinel/src/test/java/com/bytefacets/spinel/groupby/GroupByTest.java
@@ -38,6 +38,7 @@ class GroupByTest {
                 intIndexedTable("table")
                         .addField(intField("Value1"))
                         .addField(intField("Value2"))
+                        .addField(intField("Value3"))
                         .keyFieldName("Id")
                         .build();
         value1FieldId = table.fieldId("Value1");
@@ -191,6 +192,16 @@ class GroupByTest {
             changeValue1(2, 6);
             table.fireChanges();
             childValidation.expect().changed(key(2), childRowData(2, 6, null)).validate();
+        }
+
+        @Test
+        void shouldNotForwardChangesWhenNotInOutput() {
+            final var row = table.tableRow();
+            table.beginChange(2);
+            row.setInt(table.fieldId("Value3"), 5);
+            table.endChange();
+            table.fireChanges();
+            validation.expect().validate();
         }
     }
 


### PR DESCRIPTION
fix for suppressing change forwarding in GroupBy when unreferenced row change received